### PR TITLE
Tests. Added test that sends request with some random parameter inste…

### DIFF
--- a/src/test/java/ru/mail/polis/SingleNodeTest.java
+++ b/src/test/java/ru/mail/polis/SingleNodeTest.java
@@ -67,8 +67,8 @@ public class SingleNodeTest extends TestBase {
     }
 
     @NotNull
-    private String malformedParameterUrl(@NotNull final String parameter, @NotNull final String value) {
-        return "http://localhost:" + port + "/v0/entity?" + parameter + "=" + value;
+    private String absentParameterUrl() {
+        return "http://localhost:" + port + "/v0/entity";
     }
 
     private HttpResponse get(@NotNull final String key) throws IOException {
@@ -93,10 +93,10 @@ public class SingleNodeTest extends TestBase {
     }
 
     @Test
-    public void malformedParameterRequest() throws Exception{
+    public void absentParameterRequest() throws Exception{
         assertEquals(
                 400,
-                Request.Get(malformedParameterUrl(randomId(), randomId())).execute().returnResponse()
+                Request.Get(absentParameterUrl()).execute().returnResponse()
                         .getStatusLine().getStatusCode());
     }
 

--- a/src/test/java/ru/mail/polis/SingleNodeTest.java
+++ b/src/test/java/ru/mail/polis/SingleNodeTest.java
@@ -19,6 +19,7 @@ package ru.mail.polis;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -65,6 +66,11 @@ public class SingleNodeTest extends TestBase {
         return "http://localhost:" + port + "/v0/entity?id=" + id;
     }
 
+    @NotNull
+    private String malformedParameterUrl(@NotNull final String parameter, @NotNull final String value) {
+        return "http://localhost:" + port + "/v0/entity?" + parameter + "=" + value;
+    }
+
     private HttpResponse get(@NotNull final String key) throws IOException {
         return Request.Get(url(key)).execute().returnResponse();
     }
@@ -84,6 +90,14 @@ public class SingleNodeTest extends TestBase {
         assertEquals(400, get("").getStatusLine().getStatusCode());
         assertEquals(400, delete("").getStatusLine().getStatusCode());
         assertEquals(400, upsert("", new byte[]{0}).getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void malformedParameterRequest() throws Exception{
+        assertEquals(
+                400,
+                Request.Get(malformedParameterUrl(randomId(), randomId())).execute().returnResponse()
+                        .getStatusLine().getStatusCode());
     }
 
     @Test

--- a/src/test/java/ru/mail/polis/SingleNodeTest.java
+++ b/src/test/java/ru/mail/polis/SingleNodeTest.java
@@ -95,10 +95,10 @@ class SingleNodeTest extends TestBase {
 
     @Test
     public void absentParameterRequest() throws Exception{
-        assertEquals(
+        assertTimeout(TIMEOUT, () -> assertEquals(
                 400,
                 Request.Get(absentParameterUrl()).execute().returnResponse()
-                        .getStatusLine().getStatusCode());
+                        .getStatusLine().getStatusCode()));
     }
 
     @Test


### PR DESCRIPTION
…ad "id=" and random value. Handler should be aware of NullPointerException that could occurs at .getParameter("id=").isEmpty() and should respond 400.