### PR TITLE
Tests. Bug fix

### DIFF
--- a/src/test/java/ru/mail/polis/StartStopTest.java
+++ b/src/test/java/ru/mail/polis/StartStopTest.java
@@ -73,7 +73,6 @@ class StartStopTest extends TestBase {
     @Test
     void create() {
         assertTimeout(TIMEOUT, () -> {
-            KVServiceFactory.create(port, dao);
             assertThrows(IOException.class, () -> status(port));
         });
     }


### PR DESCRIPTION
В классе StartStopTest уже имеется аннотация @BeforeEach в которой создается сервер, соответственно в тесте возникает ошибка что порт уже используется, соответственно он более не проходим.